### PR TITLE
[Fix] #25- 사이드메뉴 연동

### DIFF
--- a/src/start/FAQ.js
+++ b/src/start/FAQ.js
@@ -60,12 +60,17 @@ const FAQ = () => {
       return;
     }
 
+    const userEmail = localStorage.getItem("email"); 
+
     fetch("http://localhost:8080/faq/feedback", {  // 절대 경로로 수정
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ content: feedbackText }),
+      body: JSON.stringify({
+        content: feedbackText,
+        email: userEmail, // ✅ 이메일도 함께 전송
+      }),
     })
       .then((response) => {
         console.log("응답 상태 코드:", response.status);  

--- a/src/start/FAQ.js
+++ b/src/start/FAQ.js
@@ -8,7 +8,7 @@ const FAQ = () => {
   const [openIndexes, setOpenIndexes] = useState([]); // 열려 있는 질문의 인덱스를 관리
   const [activeTab, setActiveTab] = useState("faq"); // 기본 탭: FAQ
   const [feedbackText, setFeedbackText] = useState("")
-  const [faqs, setFaqs] = useState([]);
+  const [qas, setQas] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -27,7 +27,7 @@ const FAQ = () => {
       })
       .then((data) => {
         console.log("받아온 데이터:", data);
-        setFaqs(data);
+        setQas(data);
         setLoading(false);
       })
       .catch((error) => {
@@ -60,7 +60,7 @@ const FAQ = () => {
       return;
     }
 
-    fetch("http://localhost:8080/faq/feedback", {  // ✅ 절대 경로로 수정
+    fetch("http://localhost:8080/faq/feedback", {  // 절대 경로로 수정
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -68,7 +68,7 @@ const FAQ = () => {
       body: JSON.stringify({ content: feedbackText }),
     })
       .then((response) => {
-        console.log("응답 상태 코드:", response.status);  // ✅ 응답 상태 확인
+        console.log("응답 상태 코드:", response.status);  
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
         }
@@ -76,7 +76,7 @@ const FAQ = () => {
       })
       .then((data) => {
         console.log("서버 응답 데이터:", data);
-        alert(data.message || "피드백이 정상적으로 제출되었습니다!");  // ✅ 서버 응답 메시지 표시
+        alert(data.message || "피드백이 정상적으로 제출되었습니다!");  
         setFeedbackText(""); // 입력 필드 초기화
       })
       .catch((error) => {
@@ -107,7 +107,7 @@ const FAQ = () => {
       {/* 탭 내용 */}
       {activeTab === "faq" ? (
         <div className="faq-list">
-          {faqs.map((faq, index) => (
+          {qas.map((faq, index) => (
             <div key={index} className="faq-item">
               <div className="faq-question" onClick={() => toggleAnswer(index)}>
                 <div className="faq-category">{faq.category}</div>

--- a/src/start/SideMenu_un.js
+++ b/src/start/SideMenu_un.js
@@ -21,7 +21,11 @@ const SideMenu_un = ({  }) => {
   const handleFAQQA = () => {
     navigate("/faq-qa"); 
   };
+  
+  const handleLogin=()=>{
+    window.location.href = "http://localhost:8080/oauth/kakao/login";
 
+  }
 
 
   const handleOverlayClick = (event) => {
@@ -49,7 +53,7 @@ const SideMenu_un = ({  }) => {
             <img src="/img/user.png" alt="Profile" />
           </div>
           <div className="profile-info">
-            <div className="profile-login">로그인하기 <span className="profile-arrow">&gt;</span></div>
+            <div className="profile-login"  onClick={handleLogin}  style={{ cursor: "pointer" }} >로그인하기 <span className="profile-arrow">&gt;</span></div>
           </div>
         </div>
         <div className="side-menu-body">


### PR DESCRIPTION
### Pull request
⛳️ 작업한 브랜치
- fix/jin-사이드메뉴

👷 작업한 내용
사이드메뉴의 FAQ 페이지 백엔드와 연동했습니다

🔥 변경 사항
1️⃣ FAQ
- qa는 관리자가 직접 workbench를 통해서 id, answer, category, question을 저장할 수 있도록 구현
- qa 디비에서 데이터 불러와 프론트에 표시
- feedback 저장시 해당 유저의 이메일도 함께 저장
- feedback의 id, content , email이 저장되도록 json형식으로 전달
- 오류가 우려되어 fetch시 절대경로로 백엔드 엔드포인트 연결

2️⃣ 로그인없이 사용하기 클릭시
- 사이드 메뉴의 로그인하기를 카카오로그인과 연결

### 관련 이슈
- <#25>