### PR TITLE
[feat] #33 - 카페 제보 백엔드 연동

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,7 +48,6 @@ function App() {
               <Route path="/my" element={<My />} />
               <Route path="/my/review/edit/:reviewId" element={<ReviewEdit />} />
               <Route path="/my/report/add" element={<ReporCafeAdd />} />
-              <Route path="my/report/edit/:id" element={<ReportEdit />} />
               {/* Search 컴포넌트에 onPlaceSelect 전달 */}
               <Route path="/search" element={<Search onPlaceSelect={handlePlaceSelect} />} />
               <Route path="/nickname-change" element={<NicknameChange />} />
@@ -63,6 +62,7 @@ function App() {
               <Route path="/cafe-edit" element={<CafeEdit />} />
               <Route path="/report" element={<ReportAdd />} />
               <Route path="/reportsearch" element={<ReportSearch />} />
+              <Route path="/my/report/edit/:reportedCafeId" element={<ReportEdit />} />
               <Route path="/admin/reports" element={<AdminReports />} />
               <Route path="/admin/reports/:id" element={<AdminReportDetail />} />
             </Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,10 @@ import ReviewWrite from './cafeDetail/ReviewWrite';
 import { CafeProvider } from './home/CafeContext';
 import CafeAdd from './admin/CafeAdd';
 import CafeEdit from './admin/CafeEdit';
+import AdminReports from './admin/AdminReport';
+import AdminReportDetail from './admin/AdminReportDetail';
+import ReportAdd from "./my/ReportAdd";
+import ReportSearch from "./my/ReportSearch";
 
 function App() {
   const [selectedPlace, setSelectedPlace] = useState(null); // 선택된 장소 상태
@@ -57,6 +61,10 @@ function App() {
               <Route path="/cafe/:id/review-write" element={<ReviewWrite />} />
               <Route path="/cafe-add" element={<CafeAdd />} />
               <Route path="/cafe-edit" element={<CafeEdit />} />
+              <Route path="/report" element={<ReportAdd />} />
+              <Route path="/reportsearch" element={<ReportSearch />} />
+              <Route path="/admin/reports" element={<AdminReports />} />
+              <Route path="/admin/reports/:id" element={<AdminReportDetail />} />
             </Routes>
           </BrowserRouter>
         </div>

--- a/src/admin/AdminReport.js
+++ b/src/admin/AdminReport.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const AdminReports = () => {
+  const [pendingReports, setPendingReports] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch("/report/admin/pending")
+      .then((res) => res.json())
+      .then(setPendingReports)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <div className="admin-reports">
+      <h2>미승인 제보 목록</h2>
+      {pendingReports.length === 0 ? (
+        <p>승인 대기 중인 제보가 없습니다.</p>
+      ) : (
+        <ul>
+          {pendingReports.map((report) => (
+            <li key={report.reportedCafeId} onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}>
+              {report.cafeName || "이름 없음"} ({report.kakaoPlaceId})
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AdminReports;

--- a/src/admin/AdminReport.js
+++ b/src/admin/AdminReport.js
@@ -6,8 +6,8 @@ const AdminReports = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch("/report/admin/pending")
-      .then((res) => res.json())
+    fetch("http://localhost:8080/report/admin/pending")      
+    .then((res) => res.json())
       .then(setPendingReports)
       .catch(console.error);
   }, []);
@@ -18,10 +18,15 @@ const AdminReports = () => {
       {pendingReports.length === 0 ? (
         <p>승인 대기 중인 제보가 없습니다.</p>
       ) : (
-        <ul>
+        <ul className="admin-report-list">
           {pendingReports.map((report) => (
-            <li key={report.reportedCafeId} onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}>
-              {report.cafeName || "이름 없음"} ({report.kakaoPlaceId})
+            <li
+              key={report.reportedCafeId}
+              className="admin-report-item"
+              onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}
+            >
+              <div><strong>{report.cafeName || "이름 없음"}</strong> ({report.kakaoPlaceId})</div>
+              <div><small>작성자: {report.userEmail}</small></div>
             </li>
           ))}
         </ul>

--- a/src/admin/AdminReport.js
+++ b/src/admin/AdminReport.js
@@ -2,35 +2,58 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 const AdminReports = () => {
-  const [pendingReports, setPendingReports] = useState([]);
+  const [allReports, setAllReports] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch("http://localhost:8080/report/admin/pending")      
-    .then((res) => res.json())
-      .then(setPendingReports)
+    fetch("http://localhost:8080/report/admin/all")      
+      .then((res) => res.json())
+      .then(setAllReports)
       .catch(console.error);
   }, []);
 
   return (
     <div className="admin-reports">
-      <h2>미승인 제보 목록</h2>
-      {pendingReports.length === 0 ? (
-        <p>승인 대기 중인 제보가 없습니다.</p>
-      ) : (
+      <h2>모든 제보 목록</h2>
+
+      <section>
+        <h3>검토중</h3>
         <ul className="admin-report-list">
-          {pendingReports.map((report) => (
-            <li
-              key={report.reportedCafeId}
-              className="admin-report-item"
-              onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}
-            >
+          {allReports.filter(r => r.status === "PENDING").map((report) => (
+            <li key={report.reportedCafeId} className="admin-report-item" onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}>
               <div><strong>{report.cafeName || "이름 없음"}</strong> ({report.kakaoPlaceId})</div>
               <div><small>작성자: {report.userEmail}</small></div>
             </li>
           ))}
         </ul>
-      )}
+      </section>
+
+    <br></br>
+      <section>
+        <h3>승인됨</h3>
+        <ul className="admin-report-list">
+          {allReports.filter(r => r.status === "APPROVED").map((report) => (
+            <li key={report.reportedCafeId} className="admin-report-item" onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}>
+              <div><strong>{report.cafeName || "이름 없음"}</strong> ({report.kakaoPlaceId})</div>
+              <div><small>작성자: {report.userEmail}</small></div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <br></br>
+
+      <section>
+        <h3>반려됨</h3>
+        <ul className="admin-report-list">
+          {allReports.filter(r => r.status === "REJECTED").map((report) => (
+            <li key={report.reportedCafeId} className="admin-report-item" onClick={() => navigate(`/admin/reports/${report.reportedCafeId}`)}>
+              <div><strong>{report.cafeName || "이름 없음"}</strong> ({report.kakaoPlaceId})</div>
+              <div><small>작성자: {report.userEmail}</small></div>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 };

--- a/src/admin/AdminReportDetail.js
+++ b/src/admin/AdminReportDetail.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+
+const AdminReportDetail = () => {
+  const { id } = useParams();
+  const [report, setReport] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch(`/report/admin/pending/${id}`)
+      .then((res) => res.json())
+      .then(setReport)
+      .catch(console.error);
+  }, [id]);
+
+  const handleApprove = async () => {
+    const confirm = window.confirm("해당 제보를 승인하시겠습니까?");
+    if (!confirm) return;
+
+    try {
+      const res = await fetch(`/report/admin/approve/${id}`, { method: "POST" });
+      if (res.ok) {
+        alert("승인 완료!");
+        navigate("/admin/reports");
+      } else {
+        alert("승인 실패");
+      }
+    } catch (e) {
+      console.error(e);
+      alert("오류 발생");
+    }
+  };
+
+  if (!report) return <p>불러오는 중...</p>;
+
+  return (
+    <div className="admin-report-detail">
+      <h2>제보 상세</h2>
+      <p><strong>카페 이름:</strong> {report.cafeName}</p>
+      <p><strong>카카오 ID:</strong> {report.kakaoPlaceId}</p>
+      <p><strong>내용:</strong> {report.content}</p>
+      <p><strong>작성자:</strong> {report.user?.email}</p>
+      <button onClick={handleApprove}>승인</button>
+    </div>
+  );
+};
+
+export default AdminReportDetail;

--- a/src/admin/AdminReportDetail.js
+++ b/src/admin/AdminReportDetail.js
@@ -39,7 +39,7 @@ const AdminReportDetail = () => {
       <p><strong>카페 이름:</strong> {report.cafeName}</p>
       <p><strong>카카오 ID:</strong> {report.kakaoPlaceId}</p>
       <p><strong>내용:</strong> {report.content}</p>
-      <p><strong>작성자:</strong> {report.user?.email}</p>
+      <p><strong>작성자:</strong> {report.userEmail}</p>
       <button onClick={handleApprove}>승인</button>
     </div>
   );

--- a/src/admin/AdminReportDetail.js
+++ b/src/admin/AdminReportDetail.js
@@ -43,7 +43,7 @@ const AdminReportDetail = () => {
         method: "DELETE",
       });
       if (res.ok) {
-        alert("삭제 완료!");
+        alert("반려 처리 완료!");
         navigate("/admin/reports");
       } else {
         const text = await res.text();
@@ -65,7 +65,7 @@ const AdminReportDetail = () => {
       <p><strong>내용:</strong> {report.content}</p>
       <p><strong>작성자:</strong> {report.userEmail}</p>
       <button onClick={handleApprove}>승인</button>
-      <button onClick={handleDelete} style={{ marginLeft: "10px"}}>삭제</button>
+      <button onClick={handleDelete} style={{ marginLeft: "10px"}}>반려</button>
     </div>
   );
 };

--- a/src/admin/AdminReportDetail.js
+++ b/src/admin/AdminReportDetail.js
@@ -33,6 +33,27 @@ const AdminReportDetail = () => {
       alert("오류 발생");
     }
   };
+  
+  const handleDelete = async () => {
+    const confirm = window.confirm("해당 제보를 삭제하시겠습니까?");
+    if (!confirm) return;
+  
+    try {
+      const res = await fetch(`http://localhost:8080/report/admin/delete/${id}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        alert("삭제 완료!");
+        navigate("/admin/reports");
+      } else {
+        const text = await res.text();
+        alert("삭제 실패: " + text);
+      }
+    } catch (e) {
+      console.error(e);
+      alert("오류 발생");
+    }
+  };
 
   if (!report) return <p>불러오는 중...</p>;
 
@@ -44,6 +65,7 @@ const AdminReportDetail = () => {
       <p><strong>내용:</strong> {report.content}</p>
       <p><strong>작성자:</strong> {report.userEmail}</p>
       <button onClick={handleApprove}>승인</button>
+      <button onClick={handleDelete} style={{ marginLeft: "10px"}}>삭제</button>
     </div>
   );
 };

--- a/src/admin/AdminReportDetail.js
+++ b/src/admin/AdminReportDetail.js
@@ -7,8 +7,8 @@ const AdminReportDetail = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch(`/report/admin/pending/${id}`)
-      .then((res) => res.json())
+    fetch(`http://localhost:8080/report/admin/pending/${id}`)      
+    .then((res) => res.json())
       .then(setReport)
       .catch(console.error);
   }, [id]);
@@ -18,12 +18,15 @@ const AdminReportDetail = () => {
     if (!confirm) return;
 
     try {
-      const res = await fetch(`/report/admin/approve/${id}`, { method: "POST" });
+      const res = await fetch(`http://localhost:8080/report/admin/approve/${id}`, {
+        method: "POST",
+      });
       if (res.ok) {
         alert("승인 완료!");
         navigate("/admin/reports");
       } else {
-        alert("승인 실패");
+        const text = await res.text();
+        alert("승인 실패: " + text);
       }
     } catch (e) {
       console.error(e);

--- a/src/components/CafeInformation.js
+++ b/src/components/CafeInformation.js
@@ -16,17 +16,22 @@ function CafeInformation({ onChange, selectedOptions={} }) {
   }, [selectedOptions]); //부모 컴포넌트에서 변경된 값 반영
 
   const handleOptionSelect = (category, option) => {
+    // 렌더링 중 호출 방지용 안전장치
+    if (!option || typeof option !== "string") return;
+  
     setInternalSelectedOptions((prev) => {
-        const newOptions = {
-            ...prev,
-            [category]: option, // 영어 키 유지
-        };
-        if (onChange) {
-            onChange(category, option); // 부모 컴포넌트로 전달
-        }
-        return newOptions;
+      const newOptions = {
+        ...prev,
+        [category]: option,
+      };
+      if (onChange) {
+        setTimeout(() => {
+          onChange(category, option); // ⏱️ 렌더링 이후 비동기로 호출
+        }, 0);
+      }
+      return newOptions;
     });
-};
+  };
 
 const categoryLabels = {
   wifi: "와이파이",

--- a/src/components/TagGroup.css
+++ b/src/components/TagGroup.css
@@ -21,7 +21,7 @@
     box-shadow: 0 0 0 0.5px #422919; /* Border 대신 얇은 박스 그림자 사용 */
     border-radius: 30px;
     padding: 3px 5px; /* 아이콘과 텍스트 간 여백 */
-    gap: 6px; 
+    gap: 4px; 
   }
   
   .tag-group-icon {

--- a/src/my/My.js
+++ b/src/my/My.js
@@ -69,7 +69,7 @@ useEffect(() => {
   fetchReviewedCafes();
   const fetchReportedCafes = async () => {
     try {
-      const response = await fetch(`http://localhost:8080/report/${userEmail}`);
+      const response = await fetch(`http://localhost:8080/report/user/${userEmail}`);
       if (!response.ok) throw new Error("제보한 카페 조회 실패");
       const data = await response.json();
       setReportedCafes(data);

--- a/src/my/My.js
+++ b/src/my/My.js
@@ -13,32 +13,7 @@ const My = () => {
   const [loading, setLoading] = useState(false);
   const [showDeletePopup, setShowDeletePopup] = useState(false);
   const [filters, setFilters] = useState({});
-  const [reportedCafes, setReportedCafes] = useState([
-    {
-      id: 1,
-      name: "스테이 어도러블",
-      address: "경기 용인시 기흥구 죽전로43번길 15-3 (보정동)",
-      tags: ["와이파이 빠름", "콘센트 일부", "책상 적당함", "화장실 외부", "주차 가능(무료)"],
-      description: "카페가 조용하고 공부하기 좋습니다!",
-      status: "wait", 
-    },
-    {
-      id: 2,
-      name: "카페 테라스",
-      address: "서울 강남구 테헤란로 123",
-      tags: ["와이파이 느림", "콘센트 일부", "책상 적당함", "화장실 외부", "주차 가능(무료)"],
-      description: "테라스가 멋진 카페입니다.",
-      status: "accepted", 
-    },
-    {
-      id: 3,
-      name: "조용한 카페",
-      address: "서울 송파구 방이동 45-6",
-      tags: ["와이파이 없음", "콘센트 없음", "책상 좁음", "화장실 외부", "주차 불가능"],
-      description: "조용히 책 읽기 좋은 카페입니다.",
-      status: "denied", 
-    },
-  ]);
+  const [reportedCafes, setReportedCafes] = useState([]);
 
   const userEmail = localStorage.getItem("email");
   const token= localStorage.getItem("token");
@@ -92,6 +67,17 @@ useEffect(() => {
   };
 
   fetchReviewedCafes();
+  const fetchReportedCafes = async () => {
+    try {
+      const response = await fetch(`http://localhost:8080/report/${userEmail}`);
+      if (!response.ok) throw new Error("제보한 카페 조회 실패");
+      const data = await response.json();
+      setReportedCafes(data);
+    } catch (error) {
+      console.error("제보한 카페 조회 중 오류:", error);
+    }
+  };
+  fetchReportedCafes();
 }, [userEmail, filters]); // filters 변경 시 데이터 다시 로드
 
 
@@ -206,8 +192,8 @@ useEffect(() => {
       ) : (
         <div className="report-cafe-list">
           <p className="cafe-count">총 {reportedCafes.length}개</p>
-          {reportedCafes.map((cafe) => (
-            <ReportCafeCard key={cafe.id} cafe={cafe} />
+          {reportedCafes.map((cafe, index) => (
+            <ReportCafeCard key={index} cafe={cafe} />
           ))}
         </div>
       )}

--- a/src/my/My.js
+++ b/src/my/My.js
@@ -12,6 +12,7 @@ const My = () => {
   const [reviewedCafes, setReviewedCafes] = useState([]);
   const [loading, setLoading] = useState(false);
   const [showDeletePopup, setShowDeletePopup] = useState(false);
+  const [showLoginPopup, setShowLoginPopup] = useState(false);
   const [filters, setFilters] = useState({});
   const [reportedCafes, setReportedCafes] = useState([]);
 
@@ -168,7 +169,13 @@ useEffect(() => {
       {activeTab === "reportedCafes" && (
         <button
           className="report-cafe-plus-button"
-          onClick={() => navigate("/my/report/add")}
+          onClick={() => {
+            if (!userEmail) {
+              setShowLoginPopup(true);
+              return;
+            }
+            navigate("/my/report/add");
+          }}
         >
           <img src="/img/plus.png" alt="추가버튼" />
         </button>
@@ -204,6 +211,13 @@ useEffect(() => {
           message="리뷰가 삭제되었습니다."
           onConfirm={() => setShowDeletePopup(false)}
           showCancel={false}
+      />
+    )}
+    {showLoginPopup && (
+      <Popup
+        message="로그인이 필요합니다."
+        onConfirm={() => setShowLoginPopup(false)}
+        showCancel={false}
       />
     )}
 

--- a/src/my/ReportAdd.js
+++ b/src/my/ReportAdd.js
@@ -130,6 +130,14 @@ const ReportCafeAdd = () => {
     console.log("선택된 옵션:", reportData);
 
     try {
+      const checkResponse = await fetch(`http://localhost:8080/cafes/kakao/${kakaoPlaceId}`);
+      if (checkResponse.ok) {
+        const existingCafe = await checkResponse.json();
+        if (existingCafe) {
+          alert("이미 등록된 카페입니다.");
+          return;
+        }
+      }
       const response = await fetch("http://localhost:8080/report", {
         method: "POST",
         headers: {

--- a/src/my/ReportAdd.js
+++ b/src/my/ReportAdd.js
@@ -111,7 +111,7 @@ const ReportCafeAdd = () => {
 
 
     const reportData = {
-      user: { email: userEmail },      
+      userEmail,
       kakaoPlaceId,
       cafeName: place_name,
       address: road_address_name,

--- a/src/my/ReportAdd.js
+++ b/src/my/ReportAdd.js
@@ -130,14 +130,15 @@ const ReportCafeAdd = () => {
     console.log("선택된 옵션:", reportData);
 
     try {
-      const checkResponse = await fetch(`http://localhost:8080/cafes/kakao/${kakaoPlaceId}`);
+      const checkResponse = await fetch(`http://localhost:8080/report/cafes/kakao/${kakaoPlaceId}`);
       if (checkResponse.ok) {
-        const existingCafe = await checkResponse.json();
-        if (existingCafe) {
+        const result = await checkResponse.json();
+        if (result.exists !== false) {
           alert("이미 등록된 카페입니다.");
           return;
         }
       }
+      
       const response = await fetch("http://localhost:8080/report", {
         method: "POST",
         headers: {

--- a/src/my/ReportAdd.js
+++ b/src/my/ReportAdd.js
@@ -26,6 +26,8 @@ const ReportCafeAdd = () => {
   const userEmail= localStorage.getItem("email");
   const [selectedCafe, setSelectedCafe] = useState(null);
   const [showOptionPopup, setShowOptionPopup] = useState(false);
+  const [showLoginPopup, setShowLoginPopup] = useState(false);
+  const [showNoCafePopup, setShowNoCafePopup] = useState(false);
 
   
   useEffect(() => {
@@ -84,12 +86,12 @@ const ReportCafeAdd = () => {
 
   const handleSubmit = async () => {
     if (!userEmail) {
-      alert("로그인이 필요합니다. 로그인 후 다시 시도해주세요.");
+      setShowLoginPopup(true);
       return;
     }
 
     if (!selectedCafe) {
-      alert("카페를 먼저 선택해주세요.");
+      setShowNoCafePopup(true);
       return;
     }
 
@@ -148,7 +150,6 @@ const ReportCafeAdd = () => {
       });
 
       if (response.ok) {
-        alert("제보가 완료되었습니다!");
         navigate("/my");
       } else {
         alert("제보에 실패했습니다.");
@@ -212,6 +213,21 @@ const ReportCafeAdd = () => {
         <Popup
           message="모든 옵션을 선택해주세요."
           onConfirm={() => setShowOptionPopup(false)}
+          showCancel={false}
+        />
+      )}
+      {showLoginPopup && (
+        <Popup
+          message="로그인이 필요합니다. 로그인 후 다시 시도해주세요."
+          onConfirm={() => setShowLoginPopup(false)}
+          showCancel={false}
+        />
+      )}
+
+      {showNoCafePopup && (
+        <Popup
+          message="카페를 먼저 선택해주세요."
+          onConfirm={() => setShowNoCafePopup(false)}
           showCancel={false}
         />
       )}

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -20,10 +20,17 @@ const ReportCafeCard = ({ cafe }) => {
   const [showMessage, setShowMessage] = useState(false); // 개별 메시지 상태
   const [messageType, setMessageType] = useState(null);   
   const navigate = useNavigate();
-  const status = approved ? "accepted" : "wait";
+  const status = approved ? "accepted" : (cafe.deleted ? "denied" : "wait");
 
+
+  console.log("cafe", cafe);
+  
   const handleNavigateToEdit = () => {
-    navigate(`/my/report/edit/${cafe.id}`);
+    if (status === "accepted") {
+      navigate(`/cafe/${cafe.cafe?.cafeId}`); // Navigate using cafeId
+    } else {
+      navigate(`/my/report/edit/${reportedCafeId}`);
+    }
   };
 
   const toggleDetails = () => {
@@ -32,7 +39,7 @@ const ReportCafeCard = ({ cafe }) => {
 
 
   const handleCheckClick = (type) => {
-    setMessageType(cafe.status); // 메시지 유형 설정
+    setMessageType(status); // 메시지 유형 설정
     setShowMessage(true);
   };
 
@@ -52,10 +59,10 @@ const ReportCafeCard = ({ cafe }) => {
 
   const tags = [];
   if (wifi) tags.push(`와이파이: ${wifi}`);
-if (outlets) tags.push(`콘센트: ${outlets}`);
-if (desk) tags.push(`책상: ${desk}`);
-if (restroom) tags.push(`화장실: ${restroom}`);
-if (parking) tags.push(`주차: ${parking}`);
+  if (outlets) tags.push(`콘센트: ${outlets}`);
+  if (desk) tags.push(`책상: ${desk}`);
+  if (restroom) tags.push(`화장실: ${restroom}`);
+  if (parking) tags.push(`주차: ${parking}`);
 
   const formattedTags = tags.map((tag) => {
     let iconKey = Object.keys(tagIcons).find((key) => tag.includes(key)) || "기본";
@@ -99,7 +106,16 @@ if (parking) tags.push(`주차: ${parking}`);
                 </div>
                 <p className="report-cafe-address">{address}</p>
                 <div className="report-cafe-check" onClick={() => handleCheckClick("wait")}>
-                  <img src="/img/report-wait.png" alt="Check" />
+                  <img
+                    src={
+                      status === "accepted"
+                        ? "/img/report-accepted.png"
+                        : status === "denied"
+                        ? "/img/report-denied.png"
+                        : "/img/report-wait.png"
+                    }
+                    alt="Check"
+                  />
                 </div>
             </div>
         </div>

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -4,11 +4,23 @@ import TagGroup from "../components/TagGroup";
 import "./ReportCafeCard.css";
 
 const ReportCafeCard = ({ cafe }) => {
-  const { cafeId, name , address, description, tags, status } = cafe;
+  const {
+    reportedCafeId,
+    cafeName,
+    address,
+    content,
+    approved,
+    wifi,
+    outlets,
+    desk,
+    restroom,
+    parking,
+  } = cafe;
   const [isExpanded, setIsExpanded] = useState(false);
   const [showMessage, setShowMessage] = useState(false); // 개별 메시지 상태
   const [messageType, setMessageType] = useState(null);   
   const navigate = useNavigate();
+  const status = approved ? "accepted" : "wait";
 
   const handleNavigateToEdit = () => {
     navigate(`/my/report/edit/${cafe.id}`);
@@ -38,11 +50,17 @@ const ReportCafeCard = ({ cafe }) => {
   };
 
 
+  const tags = [];
+  if (wifi) tags.push(`와이파이: ${wifi}`);
+if (outlets) tags.push(`콘센트: ${outlets}`);
+if (desk) tags.push(`책상: ${desk}`);
+if (restroom) tags.push(`화장실: ${restroom}`);
+if (parking) tags.push(`주차: ${parking}`);
+
   const formattedTags = tags.map((tag) => {
-    // 태그 키워드 기반 아이콘 매칭
-    let iconKey = Object.keys(tagIcons).find((key) => tag.includes(key)) || "기본"; // 기본값 추가 가능
+    let iconKey = Object.keys(tagIcons).find((key) => tag.includes(key)) || "기본";
     return {
-      icon: tagIcons[iconKey], 
+      icon: tagIcons[iconKey],
       text: tag,
     };
   });
@@ -67,7 +85,7 @@ const ReportCafeCard = ({ cafe }) => {
         <div className="report-cafe-header">
             <div className="report-cafe-info">
                 <div className="report-cafe-toggle">
-                    <h3 className="report-cafe-name">{cafe.name}</h3>
+                    <h3 className="report-cafe-name">{cafeName}</h3>
                     <button className="report-cafe-toggle-button" onClick={toggleDetails}>
                     <img
                     src={
@@ -79,7 +97,7 @@ const ReportCafeCard = ({ cafe }) => {
                     />
                     </button>
                 </div>
-                <p className="report-cafe-address">{cafe.address}</p>
+                <p className="report-cafe-address">{address}</p>
                 <div className="report-cafe-check" onClick={() => handleCheckClick("wait")}>
                   <img src="/img/report-wait.png" alt="Check" />
                 </div>
@@ -88,7 +106,7 @@ const ReportCafeCard = ({ cafe }) => {
 
         {isExpanded && (
         <div className="report-cafe-details">
-            <p className="report-cafe-description">{cafe.description}</p>
+            <p className="report-cafe-description">{content}</p>
             <TagGroup tags={formattedTags} />
         </div>
         )}

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -88,7 +88,6 @@ const ReportCafeCard = ({ cafe }) => {
     },
     denied: {
       text: "카페 등록이 거부되었습니다",
-      action: "자세히 보기 >",
     },
     accepted: {
       text: "카페 등록이 완료되었습니다",

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -9,7 +9,7 @@ const ReportCafeCard = ({ cafe }) => {
     cafeName,
     address,
     content,
-    approved,
+    status,
     wifi,
     outlets,
     desk,
@@ -21,13 +21,12 @@ const ReportCafeCard = ({ cafe }) => {
   const [showMessage, setShowMessage] = useState(false); // 개별 메시지 상태
   const [messageType, setMessageType] = useState(null);   
   const navigate = useNavigate();
-  const status = approved ? "accepted" : (cafe.deleted ? "denied" : "wait");
-
+  const cafeStatus = status === "APPROVED" ? "accepted" : (status === "REJECTED" ? "denied" : "wait");
 
   console.log("cafe", cafe);
   
   const handleNavigateToEdit = () => {
-    if (status === "accepted") {
+    if (cafeStatus === "accepted") {
       navigate(`/cafe/${cafe.cafe?.cafeId}`); // Navigate using cafeId
     } else {
       navigate(`/my/report/edit/${reportedCafeId}`);
@@ -40,7 +39,7 @@ const ReportCafeCard = ({ cafe }) => {
 
 
   const handleCheckClick = (type) => {
-    setMessageType(status); // 메시지 유형 설정
+    setMessageType(cafeStatus); // 메시지 유형 설정
     setShowMessage(true);
   };
 
@@ -109,9 +108,9 @@ const ReportCafeCard = ({ cafe }) => {
                 <div className="report-cafe-check" onClick={() => handleCheckClick("wait")}>
                   <img
                     src={
-                      status === "accepted"
+                      cafeStatus === "accepted"
                         ? "/img/report-accepted.png"
-                        : status === "denied"
+                        : cafeStatus === "denied"
                         ? "/img/report-denied.png"
                         : "/img/report-wait.png"
                     }

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -16,6 +16,7 @@ const ReportCafeCard = ({ cafe }) => {
     restroom,
     parking,
   } = cafe;
+  
   const [isExpanded, setIsExpanded] = useState(false);
   const [showMessage, setShowMessage] = useState(false); // 개별 메시지 상태
   const [messageType, setMessageType] = useState(null);   

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -17,19 +17,28 @@ const ReportCafeCard = ({ cafe }) => {
     parking,
   } = cafe;
   
+  
   const [isExpanded, setIsExpanded] = useState(false);
   const [showMessage, setShowMessage] = useState(false); // 개별 메시지 상태
   const [messageType, setMessageType] = useState(null);   
+  const [reviewEditText, setReviewEditText] = useState(""); // 추가된 상태
+  const [selectedOptions, setSelectedOptions] = useState([]); // 추가된 상태
+  const cafeOptions = []; // 초기화된 상태
   const navigate = useNavigate();
   const cafeStatus = status === "APPROVED" ? "accepted" : (status === "REJECTED" ? "denied" : "wait");
 
-  console.log("cafe", cafe);
   
   const handleNavigateToEdit = () => {
-    if (cafeStatus === "accepted") {
-      navigate(`/cafe/${cafe.cafe?.cafeId}`); // Navigate using cafeId
+    if (status === "PENDING") {
+      if (reportedCafeId) {
+        navigate(`/my/report/edit/${reportedCafeId}`);
+      } else {
+        alert("제보 ID가 없습니다.");
+      }
+    } else if (status === "APPROVED") {
+      navigate(`/cafe/${cafe.cafe?.cafeId}`);
     } else {
-      navigate(`/my/report/edit/${reportedCafeId}`);
+      alert("거절된 제보는 수정할 수 없습니다.");
     }
   };
 

--- a/src/my/ReportCafeCard.js
+++ b/src/my/ReportCafeCard.js
@@ -71,7 +71,14 @@ const ReportCafeCard = ({ cafe }) => {
   if (outlets) tags.push(`콘센트: ${outlets}`);
   if (desk) tags.push(`책상: ${desk}`);
   if (restroom) tags.push(`화장실: ${restroom}`);
-  if (parking) tags.push(`주차: ${parking}`);
+  
+  const parkingValueMap = {
+    "가능_무료": "가능(무료)",
+    "가능_유료": "가능(유료)",
+    "가능_일부": "가능(일부)",
+    "불가능": "불가능",
+  };
+  if (parking) tags.push(`주차: ${parkingValueMap[parking] || parking}`);
 
   const formattedTags = tags.map((tag) => {
     let iconKey = Object.keys(tagIcons).find((key) => tag.includes(key)) || "기본";

--- a/src/my/ReportEdit.js
+++ b/src/my/ReportEdit.js
@@ -68,7 +68,7 @@ const ReportEdit = () => {
         parking: cafeOptions.parking,
       };
 
-      console.log("Request body:", requestBody);
+      //console.log("Request body:", requestBody);
 
       const response = await fetch(`http://localhost:8080/report/${reportedCafeId}`, {
         method: "PUT",
@@ -167,7 +167,7 @@ const ReportEdit = () => {
 
       {showEditPopup && (
         <Popup 
-          message={`제보한 카페 "${reportData.cafeName}"의 내용이 수정되었습니다.`} 
+          message={`제보 카페 "${reportData.cafeName}"의 내용이 수정되었습니다.`} 
           onConfirm={() => {
             setShowEditPopup(false);
             navigate("/my");

--- a/src/my/ReportEdit.js
+++ b/src/my/ReportEdit.js
@@ -1,64 +1,109 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { TopBar, BottomBar, LongButton } from "../components";
 import CafeInformation from "../components/CafeInformation";
+import Popup from "../components/Popup"; // Assuming Popup component exists
 import "./MyEdit.css";
+const optionMap = {
+  "가능(무료)": "가능_무료",
+  "가능(유료)": "가능_유료",
+  "불가능": "불가능",
+  "가능(일부)": "가능_일부",
+};
 
 const ReportEdit = () => {
-  const { reportId } = useParams();
+  const { reportedCafeId } = useParams();
   const navigate = useNavigate();
+  const [reportData, setReportData] = useState(null);
+  const [cafeOptions, setCafeOptions] = useState({});
+  const [selectedOptions, setSelectedOptions] = useState({});
   const [reportEditText, setReportEditText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [showEditPopup, setShowEditPopup] = useState(false);
+  const [error, setError] = useState(null);
 
-  const handleReportEditChange = (event) => {
-    setReportEditText(event.target.value); // 입력값 상태 업데이트
-  };
+  useEffect(() => {
+    const fetchReportData = async () => {
+      setLoading(true);
+      try {
+        const response = await fetch(`http://localhost:8080/report/${reportedCafeId}`);
+        if (!response.ok) throw new Error('Network response was not ok');
+        const data = await response.json();
 
-  const mockReports = [
-    {
-      reportId: "1",
-      name: "스테이 어도러블",
-      address: "경기 용인시 기흥구 죽전로43번길 15-3",
-      wifi: "빠름",
-      outlets: "일부",
-      desk: "적당함",
-      restroom: "외부",
-      parking: "가능(무료)",
-      description: "카페 환경이 조용하고 깔끔합니다.",
-      image: "/img/cafe-img.png",
-    },
-  ];
+        const parseOption = (val) => optionMap[val] || val;
 
-  const foundReport = mockReports.find((r) => r.reportId === reportId) || {
-    name: "스테이어도러블",
-    address: "경기 용인시 기흥구 죽전로43번길 15-3",
-    wifi: "빠름",
-    outlets: "없음",
-    desk: "좁음",
-    restroom: "외부",
-    parking: "불가능",
-    description: "",
-    image: "/img/cafe-img.png",
-  };
+        const options = {
+          wifi: parseOption(data.wifi),
+          outlets: parseOption(data.outlets),
+          desk: parseOption(data.desk),
+          restroom: parseOption(data.restroom),
+          parking: parseOption(data.parking),
+        };
 
-  const [cafeOptions, setCafeOptions] = useState({
-    와이파이: foundReport.wifi,
-    콘센트: foundReport.outlets,
-    책상: foundReport.desk,
-    화장실: foundReport.restroom,
-    주차: foundReport.parking,
-  });
+        setReportData(data);
+        setCafeOptions(options);
+        setSelectedOptions(options);
+        setReportEditText(data.content || "");
+      } catch (error) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  const handleSubmit = () => {
-    alert(`제보한 카페 \"${foundReport.name}\"의 내용이 수정되었습니다.`);
-    navigate("/my");
+    fetchReportData();
+  }, [reportedCafeId]);
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true);
+
+    
+      const requestBody = {
+        content: reportEditText,
+        wifi: cafeOptions.wifi,
+        outlets: cafeOptions.outlets,
+        desk: cafeOptions.desk,
+        restroom: cafeOptions.restroom,
+        parking: cafeOptions.parking,
+      };
+
+      console.log("Request body:", requestBody);
+
+      const response = await fetch(`http://localhost:8080/report/${reportedCafeId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) throw new Error('Network response was not ok');
+      
+      setShowEditPopup(true);
+    } catch (error) {
+        console.error("Error updating report:", error);
+        alert("제보 수정에 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
   };
 
   const handleCafeOptionChange = (category, option) => {
+    const newOptionValue = optionMap[option] || option;
+
     setCafeOptions((prevOptions) => ({
       ...prevOptions,
-      [category]: option,
+      [category]: newOptionValue,
+    }));
+
+    setSelectedOptions((prevOptions) => ({
+      ...prevOptions,
+      [category]: newOptionValue,
     }));
   };
+
+
 
   return (
     <div className="my-edit-page">
@@ -71,20 +116,31 @@ const ReportEdit = () => {
         <h2>제보 수정</h2>
       </header>
 
-      <section className="my-cafe-info">
-        <img
-          src={foundReport.image || "/img/default-cafe.png"}
-          alt={foundReport.name}
-          className="my-cafe-image"
-        />
-        <div>
-          <h3 className="my-cafe-name">{foundReport.name || "카페 이름 없음"}</h3>
-          <p className="my-cafe-address">{foundReport.address || "주소 없음"}</p>
-        </div>
-      </section>
+      {loading ? (
+        <div>불러오는 중...</div>
+      ) : error ? (
+        <div>오류 발생: {error}</div>
+      ) : !reportData ? (
+        <div>불러오는 중...</div>
+      ) : (
+        <>
+          <section className="my-cafe-info">
+            <img
+              src={"/img/cafe-img.png"}
+              alt={reportData.cafeName}
+              className="my-cafe-image"
+            />
+            <div>
+              <h3 className="my-cafe-name">{reportData.cafeName}</h3>
+              <p className="my-cafe-address">{reportData.address}</p>
+            </div>
+          </section>
+
+        </>
+      )}
 
       <section className="my-form">
-        <CafeInformation onChange={handleCafeOptionChange} />
+        <CafeInformation onChange={handleCafeOptionChange} selectedOptions={selectedOptions} />
 
         <div className="my-edit-form">
           <textarea
@@ -92,7 +148,7 @@ const ReportEdit = () => {
             placeholder="이 카페에 대해 제보하고 싶은 내용을 입력해주세요."
             maxLength={200}
             value={reportEditText}
-            onChange={handleReportEditChange}
+            onChange={(e) => setReportEditText(e.target.value)}
           />
           <div className="my-edit-char-counter">
             {reportEditText.length}/200 {/* 현재 글자 수와 최대 글자 수 표시 */}
@@ -108,6 +164,17 @@ const ReportEdit = () => {
       </section>
 
       <BottomBar />
+
+      {showEditPopup && (
+        <Popup 
+          message={`제보한 카페 "${reportData.cafeName}"의 내용이 수정되었습니다.`} 
+          onConfirm={() => {
+            setShowEditPopup(false);
+            navigate("/my");
+        }}
+          showCancel={false}
+        />
+      )}
     </div>
   );
 };

--- a/src/my/ReportSearch.css
+++ b/src/my/ReportSearch.css
@@ -9,7 +9,7 @@
   }
   
   .report-search-header {
-    margin-bottom: 20px;;
+    margin-bottom: 0px;;
     padding: 5px 5px;
     display: flex;
     flex-direction: column; /* 검색창을 아래에 배치하기 위해 column 사용 */
@@ -22,9 +22,9 @@
 .search-results-list {
     list-style: none;
     padding: 10px;
-    margin-top: 1rem;
+    margin-top: 0px;
     overflow-y: auto;
-    max-height: calc(100vh - 620px); /* adjust based on map and header height */
+    max-height: calc(100vh - 320px); /* adjust based on map and header height */
 }
   
   .search-results-list li {
@@ -44,12 +44,6 @@
   .report-form {
     display: flex;
     flex-direction: column;
-    padding: 1rem;
+    padding: 10px;
     height: auto;
-  }
-
-  #map {
-    width: 100%;
-    height: 300px;
-    min-height: 300px;
   }

--- a/src/my/ReportSearch.css
+++ b/src/my/ReportSearch.css
@@ -1,0 +1,41 @@
+.report-search-page {
+    background-color: #ffffff;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch; /* 자식 요소의 가로 정렬 유지 */
+    width: 100%;
+    max-width: 393px;
+    height: 100vh;
+    overflow-y: scroll;
+  }
+  
+  .report-search-header {
+    margin-bottom: 20px;;
+    padding: 5px 5px;
+    display: flex;
+    flex-direction: column; /* 검색창을 아래에 배치하기 위해 column 사용 */
+    justify-content: center; /* 중앙 정렬 */
+    align-items: center;
+    position: relative;
+    border-bottom: 1px solid #CEC2B2; 
+  }
+  
+  .search-results-list {
+    list-style: none;
+    padding: 0;
+    margin-top: 1rem;
+  }
+  
+  .search-results-list li {
+    padding: 0.75rem 1rem;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+    cursor: pointer;
+    background-color: #f9f9f9;
+    transition: background-color 0.2s ease;
+  }
+  
+  .search-results-list li:hover {
+    background-color: #e6f7ff;
+  }

--- a/src/my/ReportSearch.css
+++ b/src/my/ReportSearch.css
@@ -6,7 +6,6 @@
     width: 100%;
     max-width: 393px;
     height: 100vh;
-    overflow-y: scroll;
   }
   
   .report-search-header {
@@ -20,11 +19,13 @@
     border-bottom: 1px solid #CEC2B2; 
   }
   
-  .search-results-list {
+.search-results-list {
     list-style: none;
-    padding: 0;
+    padding: 10px;
     margin-top: 1rem;
-  }
+    overflow-y: auto;
+    max-height: calc(100vh - 620px); /* adjust based on map and header height */
+}
   
   .search-results-list li {
     padding: 0.75rem 1rem;
@@ -38,4 +39,17 @@
   
   .search-results-list li:hover {
     background-color: #e6f7ff;
+  }
+
+  .report-form {
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    height: auto;
+  }
+
+  #map {
+    width: 100%;
+    height: 300px;
+    min-height: 300px;
   }

--- a/src/my/ReportSearch.js
+++ b/src/my/ReportSearch.js
@@ -4,12 +4,14 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { TopBar, BottomBar, LongButton } from "../components";
 import "./ReportAdd.css"
 import "./ReportSearch.css";
+import Popup from "../components/Popup";
 
 const ReportSearch = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchKeyword, setSearchKeyword] = useState(location.state?.searchKeyword);
   const [searchResults, setSearchResults] = useState([]);
+  const [showExistPopup, setShowExistPopup] = useState(false);
 
   useEffect(() => {
     const mapContainer = document.getElementById("map");
@@ -38,7 +40,17 @@ const ReportSearch = () => {
     });
   }, [searchKeyword]);
 
-  const handleSelect = (cafe) => {
+  const handleSelect = async (cafe) => {
+    const kakaoPlaceId = cafe.id;
+    const checkResponse = await fetch(`http://localhost:8080/report/cafes/kakao/${kakaoPlaceId}`);
+    if (checkResponse.status === 200) {
+      const existingCafe = await checkResponse.json();
+      if (existingCafe) {
+        setShowExistPopup(true);
+        return;
+      }
+    }
+
     navigate("/my/report/add", {
       state: {
         selectedCafe: cafe,
@@ -82,8 +94,15 @@ const ReportSearch = () => {
         ))}
       </ul>
       </section>
-
+        {showExistPopup && (
+        <Popup
+            message="이미 등록된 카페입니다."
+            onConfirm={() => setShowExistPopup(false)}
+            showCancel={false}
+        />
+        )}
     </div>
+    
   );
 };
 

--- a/src/my/ReportSearch.js
+++ b/src/my/ReportSearch.js
@@ -14,31 +14,13 @@ const ReportSearch = () => {
   const [showExistPopup, setShowExistPopup] = useState(false);
 
   useEffect(() => {
-    const mapContainer = document.getElementById("map");
-    if (!mapContainer || !searchKeyword) return;
+    if (!searchKeyword) return;
 
-    const mapOption = {
-      center: new kakao.maps.LatLng(37.5665, 126.9780),
-      level: 3,
-    };
-    const map = new kakao.maps.Map(mapContainer, mapOption);
     const ps = new kakao.maps.services.Places();
-
     ps.keywordSearch(searchKeyword, (data, status) => {
       if (status === kakao.maps.services.Status.OK) {
         const cafes = data.filter((place) => place.category_group_code === "CE7");
         setSearchResults(cafes);
-
-        const bounds = new kakao.maps.LatLngBounds();
-        cafes.forEach((place) => {
-          const loc = new kakao.maps.LatLng(place.y, place.x);
-          bounds.extend(loc);
-          new kakao.maps.Marker({ map, position: loc });
-        });
-        requestAnimationFrame(() => {
-          map.setBounds(bounds);
-          map.relayout();
-        });
       }
     });
   }, [searchKeyword]);
@@ -90,27 +72,24 @@ const ReportSearch = () => {
         </div>
       </header>
 
-
       <section className="report-form" style={{ height: "auto" }}>
-      <div id="map" style={{ width: "100%", height: "300px", minHeight: "300px" }}></div>
-      <ul className="search-results-list">
-        {searchResults.map((place) => (
-          <li key={place.id} onClick={() => handleSelect(place)}>
-            <strong>{place.place_name}</strong> <br />
-            <small>{place.road_address_name}</small>
-          </li>
-        ))}
-      </ul>
+        <ul className="search-results-list">
+          {searchResults.map((place) => (
+            <li key={place.id} onClick={() => handleSelect(place)}>
+              <strong>{place.place_name}</strong> <br />
+              <small>{place.road_address_name}</small>
+            </li>
+          ))}
+        </ul>
       </section>
-        {showExistPopup && (
+      {showExistPopup && (
         <Popup
             message="이미 등록된 카페입니다."
             onConfirm={() => setShowExistPopup(false)}
             showCancel={false}
         />
-        )}
+      )}
     </div>
-    
   );
 };
 

--- a/src/my/ReportSearch.js
+++ b/src/my/ReportSearch.js
@@ -42,15 +42,20 @@ const ReportSearch = () => {
 
   const handleSelect = async (cafe) => {
     const kakaoPlaceId = cafe.id;
-    const checkResponse = await fetch(`http://localhost:8080/report/cafes/kakao/${kakaoPlaceId}`);
-    if (checkResponse.status === 200) {
-      const existingCafe = await checkResponse.json();
-      if (existingCafe) {
-        setShowExistPopup(true);
-        return;
+  
+    try {
+      const checkResponse = await fetch(`http://localhost:8080/report/cafes/kakao/${kakaoPlaceId}`);
+      if (checkResponse.ok) {
+        const result = await checkResponse.json();
+        if (result.exists !== false) {
+          setShowExistPopup(true);
+          return;
+        }
       }
+    } catch (error) {
+      console.error("카페 확인 중 오류 발생:", error);
     }
-
+  
     navigate("/my/report/add", {
       state: {
         selectedCafe: cafe,
@@ -58,6 +63,8 @@ const ReportSearch = () => {
       },
     });
   };
+
+
 
   return (
     <div className="report-search-page">

--- a/src/my/ReportSearch.js
+++ b/src/my/ReportSearch.js
@@ -35,7 +35,10 @@ const ReportSearch = () => {
           bounds.extend(loc);
           new kakao.maps.Marker({ map, position: loc });
         });
-        map.setBounds(bounds);
+        requestAnimationFrame(() => {
+          map.setBounds(bounds);
+          map.relayout();
+        });
       }
     });
   }, [searchKeyword]);
@@ -64,8 +67,6 @@ const ReportSearch = () => {
     });
   };
 
-
-
   return (
     <div className="report-search-page">
      <TopBar title="# My" />
@@ -90,8 +91,8 @@ const ReportSearch = () => {
       </header>
 
 
-      <section className="report-form">
-      <div id="map" style={{ width: "100%", height: "300px" }}></div>
+      <section className="report-form" style={{ height: "auto" }}>
+      <div id="map" style={{ width: "100%", height: "300px", minHeight: "300px" }}></div>
       <ul className="search-results-list">
         {searchResults.map((place) => (
           <li key={place.id} onClick={() => handleSelect(place)}>

--- a/src/my/ReportSearch.js
+++ b/src/my/ReportSearch.js
@@ -1,0 +1,90 @@
+/*global kakao*/
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { TopBar, BottomBar, LongButton } from "../components";
+import "./ReportAdd.css"
+import "./ReportSearch.css";
+
+const ReportSearch = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [searchKeyword, setSearchKeyword] = useState(location.state?.searchKeyword);
+  const [searchResults, setSearchResults] = useState([]);
+
+  useEffect(() => {
+    const mapContainer = document.getElementById("map");
+    if (!mapContainer || !searchKeyword) return;
+
+    const mapOption = {
+      center: new kakao.maps.LatLng(37.5665, 126.9780),
+      level: 3,
+    };
+    const map = new kakao.maps.Map(mapContainer, mapOption);
+    const ps = new kakao.maps.services.Places();
+
+    ps.keywordSearch(searchKeyword, (data, status) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const cafes = data.filter((place) => place.category_group_code === "CE7");
+        setSearchResults(cafes);
+
+        const bounds = new kakao.maps.LatLngBounds();
+        cafes.forEach((place) => {
+          const loc = new kakao.maps.LatLng(place.y, place.x);
+          bounds.extend(loc);
+          new kakao.maps.Marker({ map, position: loc });
+        });
+        map.setBounds(bounds);
+      }
+    });
+  }, [searchKeyword]);
+
+  const handleSelect = (cafe) => {
+    navigate("/my/report/add", {
+      state: {
+        selectedCafe: cafe,
+        searchKeyword: cafe.place_name,
+      },
+    });
+  };
+
+  return (
+    <div className="report-search-page">
+     <TopBar title="# My" />
+
+     <header className="report-cafe-add-header">
+        <div className="report-header-container"> 
+        <button className="back-button" onClick={() => navigate("/my/report/add")}>
+          <img src="/img/back-button.png" alt="뒤로가기" />
+        </button>
+        <h2>카페 검색</h2>
+        </div>
+
+        <div className="report-add-search">
+          <input
+            type="text"
+            className="report-search-input"
+            placeholder="카페명을 검색하세요"
+            value={searchKeyword}
+            onChange={(e) => setSearchKeyword(e.target.value)}
+            />
+        </div>
+      </header>
+
+
+      <section className="report-form">
+      <div id="map" style={{ width: "100%", height: "300px" }}></div>
+      <ul className="search-results-list">
+        {searchResults.map((place) => (
+          <li key={place.id} onClick={() => handleSelect(place)}>
+            <strong>{place.place_name}</strong> <br />
+            <small>{place.road_address_name}</small>
+          </li>
+        ))}
+      </ul>
+      </section>
+
+    </div>
+  );
+};
+
+export default ReportSearch;


### PR DESCRIPTION
### Pull request
⛳️ 작업한 브랜치
- #33 

👷 작업한 내용
태그에 따른 리뷰 필터링, 카페 제보 구현에 따른 백엔드 연동 및 구현

🔥 변경 사항
1️⃣ 태그에 따른 리뷰 필터링

2️⃣ ReportSearch
- 카카오맵 연결해 카페 검색 화면 구현
- 이미 있는 카페 선택시 팝업

3️⃣ 카페 제보 화면
- RepotSearch에서 선택한 카페에 대한 제보 작성

4️⃣ 카페 제보 조회
- APPROVED, PENDING, REJECTED에 따른 제보 상태 아이콘, 메세지 표시
- 승인시 카페 상세 페이지 연결
- 대기시 카페 제보 수정 가능

5️⃣ 관리자 페이지
- 제보목록 조회, 승인반려 선택 html


### 관련 이슈
- <#33>