### PR TITLE
[Fix] #46 프론트 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,7 +60,7 @@ function App() {
               <Route path="/faq-qa" element={<FAQ />} />
               <Route path="/cafe/:id" element={<CafeDetail />} />
               <Route path="/cafe/:id/review-write" element={<ReviewWrite />} />
-              <Route path="/cafe-add" element={<CafeAdd />} />
+              <Route path="/admin/cafe-add" element={<CafeAdd />} />
               <Route path="/cafe-edit" element={<CafeEdit />} />
               <Route path="/report" element={<ReportAdd />} />
               <Route path="/reportsearch" element={<ReportSearch />} />

--- a/src/admin/CafeAdd.js
+++ b/src/admin/CafeAdd.js
@@ -152,7 +152,7 @@ const CafeAdd = () => {
         googleDetails.photos && googleDetails.photos.length > 0
           ? googleDetails.photos
             .slice(0, 5)
-            .map(photo => photo.getUrl({ maxWidth: 400 }))
+            .map(photo => photo.getUrl({ maxWidth: 1600 }))
           : [];
 
 

--- a/src/components/CafeInformationDetail.js
+++ b/src/components/CafeInformationDetail.js
@@ -47,7 +47,7 @@ function convertTo24Hour(timeStr) {
 }
 
 function getBusinessStatus(parsedHours) {
-  const now = new Date();
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
   const todayIdx = now.getDay(); // 0 = 일, 1 = 월
   const dayMap = ["일", "월", "화", "수", "목", "금", "토"];
   const today = dayMap[todayIdx];

--- a/src/my/ReportAdd.js
+++ b/src/my/ReportAdd.js
@@ -203,7 +203,7 @@ const ReportCafeAdd = () => {
         address: road_address_name,
         latitude: y,
         longitude: x,
-        phoneNumber: phone || "",
+        phoneNumber: phone || "정보 없음",
         websiteUrl: website,
         openingHours: openingHours,
         content: reportText,

--- a/src/my/ReportAdd.js
+++ b/src/my/ReportAdd.js
@@ -120,8 +120,21 @@ const ReportCafeAdd = () => {
 
     return weekdayTextArray
       .map((entry) => {
-        const [day, timeRange] = entry.split(": ");
-        if (!day || !timeRange || !timeRange.includes("~")) return `${day}: 휴무일`;
+        // 예외 항목 (요일 없는 문구)
+        if (!entry.includes(":")) {
+          if (entry.includes("시간이 달라질 수 있음")) return "기타: 시간 변동 가능";
+          return `기타: ${entry}`;
+        }
+
+        const colonIndex = entry.indexOf(":");
+        const day = entry.slice(0, colonIndex);
+        const timeRange = entry.slice(colonIndex + 1).trim();
+
+        if (!day || !timeRange) return `${day}: 정보 없음`;
+
+        if (timeRange.includes("휴무일")) return `${day}: 휴무일`;
+        if (timeRange.includes("24시간 영업")) return `${day}: 24시간 영업`;
+        if (timeRange.includes("시간이 달라질 수 있음")) return `${day}: 시간 변동 가능`;
 
         let [startRaw, endRaw] = timeRange.split("~").map(s => s.trim());
 


### PR DESCRIPTION
## Pull Request

### 👷🏻‍♂️ [1] 전화번호 정보없음 넣기

제보 카페 저장시 전화번호 없을 경우 '정보 없음'으로 처리되도록 했습니당

### 👷🏻‍♂️ [2] 영업시간 필터링

🔥 필터링 수행은 백엔드에서 처리, 상세페이지 운영시간 확인은 프론트에서 처리함니다 🔥

**1. 로컬에서는 필터링 잘 됨**

➡️ CafeService.isOpenNow()에서 사용하는 LocalDateTime.now()가 운영체제 시간(KST)을 따르기 때문에 "영업중" 필터가 정확한 현재 시간 기준으로 판단되어 정상 작동

**2. 배포단에서는 필터링 안 됨**

➡️ 배포 서버(JVM)의 기본 시간대는 UTC으로 추측됨 그래서 LocalDateTime.now()는 KST보다 9시간 느리고 isOpenNow()에서 영업 시작 시간 이전으로 잘못 판단 → false 반환
➡️ 24시간 영업은 시간대에 무관하므로 정상 작동

(아래 예시에서 스타벅스 성복역점은 운영시간을 임시로 오전 5-6시로 설정해서 현재 영업중 필터링이 수행됨)

|로컬 필터링 - 영업중|배포단 필터링 - 영업중|배포단 필터링 - 24시간|
|--|--|--|
|<img width="230" alt="Image" src="https://github.com/user-attachments/assets/398c5328-f223-4043-8da4-458055c5c07e" />|<img width="230" alt="Image" src="https://github.com/user-attachments/assets/7cf28229-5a3f-4b92-85b8-ff3ab511942f" />|<img width="230" alt="Image" src="https://github.com/user-attachments/assets/b489485c-6f84-45ca-a1df-d9c185b5d777" />|

**3. 상세 페이지 운영시간은 로컬/배포 모두 잘 나옴**

➡️ 프론트의 CafeInformationDetail 컴포넌트는 new Date()를 사용하여 브라우저(클라이언트)의 현재 시간대를 기준으로 판단
즉, 사용자 컴퓨터 시간이 KST이면 항상 KST 기준으로 "영업중" 판단
백엔드 시간대와 무관하게 항상 사용자 기준으로 정확히 판단되므로 정상 작동

**결론**
|구분 | 동작 | 이유 | 해결책|
|-- | -- | -- | --|
|로컬 필터링 | ✅ 정상 작동 | JVM 시간대 = KST | 그대로 유지|
|배포 필터링 | ❌ 잘못 작동 | JVM 시간대 = UTC | JVM 시간대를 Asia/Seoul로 설정|
|상세페이지 운영시간 | ✅ 정상 작동 | 브라우저 시간 기준 | 한국 카페를 기준으로 하므로 어느 시간대에서 확인해도 한국 기준에 맞추도록 KST로 변경|


즉, 필터링 로직 관련 코드에서 수정할 부분은 없었고, 상세 페이지 운영시간 확인 시 KST로 고정되도록 그 부분만 수정했습니다!
docker에서 시간대 설정 부탁드려요


### 👷🏻‍♂️ [3] cafe-add 관련

구글맵 API 연동 이전 이슈에서 처리 안한 줄 알았는데 제가 해놨더라구요 🫨
path를 /cafe-add 에서 /admin/cafe-add로, 구글에 사진 요청시 400px에서 1600px으로 자잘한 부분만 수정했습니다!
